### PR TITLE
add dependabot to create PR to update the submodules to latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
mostly done as proof of concept to test if ok to run dependabot submodule version update if repo has no submodules.